### PR TITLE
Adds deployment probe and action

### DIFF
--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -117,6 +117,7 @@ def trigger_deployment(name: str, ns: "default", secrets: Secrets = None):
     v1 = client.AppsV1Api(api)
     deployment = v1.read_namespaced_deployment(name, ns)
     for container in deployment.spec.template.spec.containers:
-        container.env.append(V1EnvVar("ENV-{}".format(str(uuid.uuid4())), "value"))
+        container.env.append(
+            V1EnvVar("ENV-{}".format(str(uuid.uuid4())), "value")
+        )
     v1.replace_namespaced_deployment(name, ns, deployment)
-

--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -117,6 +117,6 @@ def trigger_deployment(name: str, ns: "default", secrets: Secrets = None):
     v1 = client.AppsV1Api(api)
     deployment = v1.read_namespaced_deployment(name, ns)
     for container in deployment.spec.template.spec.containers:
-        container.env.append(V1EnvVar(str(uuid.uuid4()), "value"))
+        container.env.append(V1EnvVar("ENV-{}".format(str(uuid.uuid4())), "value"))
     v1.replace_namespaced_deployment(name, ns, deployment)
 

--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -118,6 +118,6 @@ def trigger_deployment(name: str, ns: "default", secrets: Secrets = None):
     deployment = v1.read_namespaced_deployment(name, ns)
     for container in deployment.spec.template.spec.containers:
         container.env.append(
-            V1EnvVar("ENV-{}".format(str(uuid.uuid4())), "value")
+            V1EnvVar("CHAOS_TOOLKIT_TRIGGER_DEPLOYMENT", str(uuid.uuid4()))
         )
     v1.replace_namespaced_deployment(name, ns, deployment)

--- a/chaosk8s/deployment/probes.py
+++ b/chaosk8s/deployment/probes.py
@@ -155,12 +155,12 @@ def deployment_not_fully_available(
     :exc:`chaoslib.exceptions.ActivityFailed` exception is raised.
     """
     if _deployment_readiness_has_state(
-            name,
-            False,
-            ns,
-            label_selector,
-            timeout,
-            secrets,
+        name,
+        False,
+        ns,
+        label_selector,
+        timeout,
+        secrets,
     ):
         return True
     else:
@@ -181,12 +181,12 @@ def deployment_fully_available(
     :exc:`chaoslib.exceptions.ActivityFailed` exception is raised.
     """
     if _deployment_readiness_has_state(
-            name,
-            True,
-            ns,
-            label_selector,
-            timeout,
-            secrets,
+        name,
+        True,
+        ns,
+        label_selector,
+        timeout,
+        secrets,
     ):
         return True
     else:

--- a/chaosk8s/deployment/probes.py
+++ b/chaosk8s/deployment/probes.py
@@ -69,13 +69,20 @@ def wait_for_rollout_completion(
     timeout = current_time + datetime.timedelta(0, timeout_secs)
     while datetime.datetime.now() < timeout:
         deployment = v1.read_namespaced_deployment(name, ns)
-        if deployment.spec.replicas == deployment.status.available_replicas:
+        desired_replicas = deployment.spec.replicas
+        available_replicas = deployment.status.available_replicas
+        logger.info(
+            ("probe found {} available replicas compared to {} expected " +
+             "replicas").format(available_replicas, desired_replicas)
+        )
+        if desired_replicas == available_replicas:
             return
         time.sleep(interval_secs)
     raise ActivityFailed(
-        "deployment {} failed to complete rollout in {} seconds".format(
-            name, timeout_secs
-        ))
+        ("deployment {} failed to complete rollout in {} seconds, with {}" +
+         "available replicas compared to {} expected").format(
+            name, timeout_secs, available_replicas, desired_replicas)
+    )
 
 
 def _deployment_readiness_has_state(
@@ -148,12 +155,12 @@ def deployment_not_fully_available(
     :exc:`chaoslib.exceptions.ActivityFailed` exception is raised.
     """
     if _deployment_readiness_has_state(
-        name,
-        False,
-        ns,
-        label_selector,
-        timeout,
-        secrets,
+            name,
+            False,
+            ns,
+            label_selector,
+            timeout,
+            secrets,
     ):
         return True
     else:
@@ -174,12 +181,12 @@ def deployment_fully_available(
     :exc:`chaoslib.exceptions.ActivityFailed` exception is raised.
     """
     if _deployment_readiness_has_state(
-        name,
-        True,
-        ns,
-        label_selector,
-        timeout,
-        secrets,
+            name,
+            True,
+            ns,
+            label_selector,
+            timeout,
+            secrets,
     ):
         return True
     else:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -7,7 +7,7 @@ from chaoslib.exceptions import ActivityFailed
 from kubernetes.client.models import V1DeploymentList, V1Deployment, V1ObjectMeta
 
 from chaosk8s.deployment.actions import create_deployment, delete_deployment, \
-    scale_deployment, update_image
+    scale_deployment, update_image, trigger_deployment
 from chaosk8s.deployment.probes import deployment_not_fully_available, \
     deployment_available_and_healthy, deployment_fully_available
 
@@ -45,10 +45,12 @@ def test_update_image_when_container_is_found(client, api):
     container_mock.name = "container_name"
     deployment_mock.spec.template.spec.containers = [container_mock]
     v1.read_namespaced_deployment.return_value = deployment_mock
+
     update_image(name="deployment_name",
                  image="image:tag",
                  ns="default",
                  container_name=container_mock.name)
+
     v1.replace_namespaced_deployment.assert_called_once_with(ANY, ANY, ANY)
 
 
@@ -62,12 +64,32 @@ def test_update_image_when_container_is_not_found(client, api):
     container_mock.name = "container_name"
     deployment_mock.spec.template.spec.containers = [container_mock]
     v1.read_namespaced_deployment.return_value = deployment_mock
+
     with pytest.raises(ActivityFailed) as excinfo:
         update_image(name="deployment_name",
                  image="image:tag",
                  ns="default",
                  container_name="not_container_name")
+
     assert "container with the given name was not found" in str(excinfo)
+
+
+@patch('chaosk8s.deployment.actions.create_k8s_api_client', autospec=True)
+@patch('chaosk8s.deployment.actions.client', autospec=True)
+def test_trigger_deployment_adds_env_var(client, api):
+    v1 = MagicMock()
+    client.AppsV1Api.return_value = v1
+    deployment_mock = MagicMock()
+    container_mock = MagicMock()
+    container_mock.env = [MagicMock()]
+    deployment_mock.spec.template.spec.containers = [container_mock]
+    v1.read_namespaced_deployment.return_value = deployment_mock
+
+    trigger_deployment("deployment_name", "default")
+
+    deployment = v1.replace_namespaced_deployment.call_args[0][2]
+    assert len(deployment.spec.template.spec.containers) == 1
+    assert len(deployment.spec.template.spec.containers[0].env) == 2
 
 
 @patch('chaosk8s.deployment.actions.create_k8s_api_client', autospec=True)


### PR DESCRIPTION
This PR introduces:
* An action that can be used to trigger the rollout of a deployment's replicaset by introducing a dummy environment variable with a random value. This is preferable to updating the container image, because no knowledge of the container is required in order to trigger a rollout.
* A probe that can wait for a rollout to be completed before returning.