### PR TITLE
Check if pod volumes is None

### DIFF
--- a/chaosk8s/node/actions.py
+++ b/chaosk8s/node/actions.py
@@ -282,7 +282,7 @@ def drain_nodes(name: str = None, label_selector: str = None,
                              "node '{}'".format(name, node_name))
                 continue
 
-            if any(filter(lambda v: v.empty_dir is not None, volumes)):
+            if volumes and any(filter(lambda v: v.empty_dir is not None, volumes)):
                 logger.debug(
                     "Pod '{}' on node '{}' has a volume made "
                     "of a local storage".format(name, node_name))

--- a/chaosk8s/node/actions.py
+++ b/chaosk8s/node/actions.py
@@ -282,7 +282,8 @@ def drain_nodes(name: str = None, label_selector: str = None,
                              "node '{}'".format(name, node_name))
                 continue
 
-            if volumes and any(filter(lambda v: v.empty_dir is not None, volumes)):
+            if volumes and any(
+                    filter(lambda v: v.empty_dir is not None, volumes)):
                 logger.debug(
                     "Pod '{}' on node '{}' has a volume made "
                     "of a local storage".format(name, node_name))


### PR DESCRIPTION
This fixes 
```
[2020-06-26 13:43:36 ERROR]   => failed: TypeError: 'NoneType' object is not iterable
```
error when running tests using https://github.com/form3tech/chaos-tests/pull/12/files 

kubernetes mat deliver a `None` array when a list of pods is queried, which was causing this run to fail when evicting pods from the nodes that were being drained
